### PR TITLE
Fix slow DN backed HashMap update

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/scostore/JoinListStore.java
+++ b/src/main/java/org/datanucleus/store/rdbms/scostore/JoinListStore.java
@@ -298,7 +298,7 @@ public class JoinListStore<E> extends AbstractListStore<E>
                         start++;
 
                         // Execute the statement
-                        sqlControl.executeStatementUpdate(ec, mconn, addStmt, ps, !iter.hasNext());
+                        sqlControl.executeStatementUpdate(ec, mconn, addStmt, ps, !elemIter.hasNext());
                     }
                     finally
                     {


### PR DESCRIPTION
The JoinMapStore (backend for HashMap) is slow creation/replace when map size glow.

1. It sent one SELECT for each KEY before INSERT/UPDATE which cause high number of round-trip.
2. The SQL batching was not implemented.

This PR attempt to fix by do one flat SELECT before INSERT. and improve batching save/update.

Worth to note that there are likely few other bug found during the above fix.
1. wrong iter variable used in JoinListStore.  <- also fixed
2. getValue using a cached SQL may with wrong FetchPlan/group  <- also fixed 
3. Dependent value auto deletion is likely broken in putAll <-not fixed